### PR TITLE
Resolved issue with optional moderator field not existing.

### DIFF
--- a/app/controllers/simple_discussion/application_controller.rb
+++ b/app/controllers/simple_discussion/application_controller.rb
@@ -12,7 +12,7 @@ class SimpleDiscussion::ApplicationController < ::ApplicationController
   end
   helper_method :is_moderator_or_owner?
 
-  def is_moderator?
+  def self.is_moderator?
     current_user.respond_to?(:moderator) && current_user.moderator?
   end
   helper_method :is_moderator?

--- a/app/controllers/simple_discussion/application_controller.rb
+++ b/app/controllers/simple_discussion/application_controller.rb
@@ -12,7 +12,7 @@ class SimpleDiscussion::ApplicationController < ::ApplicationController
   end
   helper_method :is_moderator_or_owner?
 
-  def self.is_moderator?
+  def is_moderator?
     current_user.respond_to?(:moderator) && current_user.moderator?
   end
   helper_method :is_moderator?

--- a/app/controllers/simple_discussion/forum_posts_controller.rb
+++ b/app/controllers/simple_discussion/forum_posts_controller.rb
@@ -53,7 +53,7 @@ class SimpleDiscussion::ForumPostsController < SimpleDiscussion::ApplicationCont
     end
 
     def set_forum_post
-      if current_user.moderator?
+      if is_moderator?
         @forum_post = @forum_thread.forum_posts.find(params[:id])
       else
         @forum_post = current_user.forum_posts.find(params[:id])

--- a/app/views/simple_discussion/forum_posts/_forum_post.html.erb
+++ b/app/views/simple_discussion/forum_posts/_forum_post.html.erb
@@ -38,7 +38,7 @@
         <% if is_moderator_or_owner?(@forum_thread) %>
           <small>
             <%= link_to "Undo", simple_discussion.unsolved_forum_thread_forum_post_path(@forum_thread, forum_post), method: :put %>
-          </small
+          </small>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
Resolves issue when editing a post if you haven't added the moderator field to your user table.

Simple change to allow the `is_moderator?` method to be called from another controller and then a chance from `current_user.moderator?` to `is_moderator?`. I don't know if this is the best way to handle this, but it's what I could come up with.

Closes #4.