### PR TITLE
Fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@ The gem is available as open source under the terms of the [MIT License](http://
 
 ## Code of Conduct
 
-Everyone interacting in the SimpleDiscussion project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/excid/simple_discussion/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the SimpleDiscussion project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/excid3/simple_discussion/blob/master/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@ The gem is available as open source under the terms of the [MIT License](http://
 
 ## Code of Conduct
 
-Everyone interacting in the SimpleDiscussion project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/simple_discussion/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the SimpleDiscussion project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/excid/simple_discussion/blob/master/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Fixed the code of conduct link to point to the actual code of conduct and not a dead link.