### PR TITLE
Fixes editing a forum post in another persons threads

### DIFF
--- a/app/controllers/simple_discussion/application_controller.rb
+++ b/app/controllers/simple_discussion/application_controller.rb
@@ -17,9 +17,21 @@ class SimpleDiscussion::ApplicationController < ::ApplicationController
   end
   helper_method :is_moderator?
 
-  def require_moderator_or_author!
-    unless is_moderator_or_owner?(@forum_thread)
-      redirect_to simple_discussion.root_path, alert: "You aren't allowed to do that."
+  def require_mod_or_author_for_post!
+    unless is_moderator_or_owner?(@forum_post)
+      redirect_to_root
     end
+  end
+
+  def require_mod_or_author_for_thread!
+    unless is_moderator_or_owner?(@forum_thread)
+      redirect_to_root
+    end
+  end
+
+  private
+
+  def redirect_to_root
+    redirect_to simple_discussion.root_path, alert: "You aren't allowed to do that."
   end
 end

--- a/app/controllers/simple_discussion/forum_posts_controller.rb
+++ b/app/controllers/simple_discussion/forum_posts_controller.rb
@@ -2,7 +2,8 @@ class SimpleDiscussion::ForumPostsController < SimpleDiscussion::ApplicationCont
   before_action :authenticate_user!
   before_action :set_forum_thread
   before_action :set_forum_post, only: [:edit, :update]
-  before_action :require_moderator_or_author!, only: [:edit, :update, :solved, :unsolved]
+  before_action :require_mod_or_author_for_post!, only: [:edit, :update]
+  before_action :require_mod_or_author_for_thread!, only: [:solved, :unsolved]
 
   def create
     @forum_post = @forum_thread.forum_posts.new(forum_post_params)

--- a/app/controllers/simple_discussion/forum_threads_controller.rb
+++ b/app/controllers/simple_discussion/forum_threads_controller.rb
@@ -1,7 +1,7 @@
 class SimpleDiscussion::ForumThreadsController < SimpleDiscussion::ApplicationController
   before_action :authenticate_user!, only: [:mine, :participating, :new, :create]
   before_action :set_forum_thread, only: [:show, :edit, :update]
-  before_action :require_moderator_or_author!, only: [:edit, :update]
+  before_action :require_mod_or_author_for_thread!, only: [:edit, :update]
 
   def index
     @forum_threads = ForumThread.pinned_first.sorted.includes(:user, :forum_category).paginate(page: page_number)


### PR DESCRIPTION
**Bug**

Previously, you were not able to edit your own forum post you made in a thread someone else created.

This fixes that by breaking them out into two before_actions

Solving/Unsolving a post requires the forum thread author to do which explains why I added the forum_thread before action in the ForumPosts controller

Let me know if you'd like me to bump the version in this PR :)