### PR TITLE
Fixes on initial install

### DIFF
--- a/app/controllers/simple_discussion/forum_posts_controller.rb
+++ b/app/controllers/simple_discussion/forum_posts_controller.rb
@@ -1,8 +1,8 @@
 class SimpleDiscussion::ForumPostsController < SimpleDiscussion::ApplicationController
   before_action :authenticate_user!
   before_action :set_forum_thread
-  before_action :set_forum_post, only: [:edit, :update]
-  before_action :require_mod_or_author_for_post!, only: [:edit, :update]
+  before_action :set_forum_post, only: [:edit, :update, :destroy]
+  before_action :require_mod_or_author_for_post!, only: [:edit, :update, :destroy]
   before_action :require_mod_or_author_for_thread!, only: [:solved, :unsolved]
 
   def create
@@ -26,6 +26,11 @@ class SimpleDiscussion::ForumPostsController < SimpleDiscussion::ApplicationCont
     else
       render action: :edit
     end
+  end
+
+  def destroy
+    @forum_post.destroy!
+    redirect_to simple_discussion.forum_thread_path(@forum_thread)
   end
 
   def solved

--- a/app/views/layouts/simple_discussion.html.erb
+++ b/app/views/layouts/simple_discussion.html.erb
@@ -77,7 +77,7 @@
 
         <%= link_to simple_discussion.forum_thread_notifications_path(@forum_thread), method: :post, class: "btn btn-secondary btn-sm btn-block mb-2" do %>
           <% if @forum_thread.subscribed? current_user %>
-            <%= icon "bell-slash" %> t('.unsubscribe')
+            <%= icon "bell-slash" %> <%= t('.unsubscribe') %>
           <% else %>
             <%= icon "bell" %>
             <%= t('.suscribe') %>

--- a/app/views/layouts/simple_discussion.html.erb
+++ b/app/views/layouts/simple_discussion.html.erb
@@ -19,32 +19,32 @@
         </h5>
         <div>
           <%= forum_link_to simple_discussion.forum_threads_path, exact: true do %>
-            <%= icon "fas", "bars" %>
+            <%= icon "fa-fw fas", "bars" %>
             <%= t('.all_threads') %>
           <% end %>
         </div>
         <% if user_signed_in? %>
           <div>
-            <%= forum_link_to simple_discussion.mine_forum_threads_path do %><%= icon "far", "user-circle" %>
+            <%= forum_link_to simple_discussion.mine_forum_threads_path do %><%= icon "fa-fw far", "user-circle" %>
               <%= t('.my_questions') %>
             <% end %>
           </div>
           <div>
             <%= forum_link_to simple_discussion.participating_forum_threads_path do %>
-              <%= icon "far", "comments" %>
+              <%= icon "fa-fw far", "comments" %>
               <%= t('.participating') %>
             <% end %>
           </div>
         <% end %>
         <div>
           <%= forum_link_to simple_discussion.answered_forum_threads_path do %>
-            <%= icon "fas", "check" %>
+            <%= icon "fa-fw fas", "check" %>
             <%= t('.answered') %>
           <% end %>
         </div>
         <div>
           <%= forum_link_to simple_discussion.unanswered_forum_threads_path do %>
-            <%= icon "fas", "question" %>
+            <%= icon "fa-fw fas", "question" %>
             <%= t('.unanswered') %>
           <% end %>
         </div>
@@ -58,11 +58,11 @@
             <%= t('.by_category') %>
           </strong>
         </h6>
-        <div><%= forum_link_to simple_discussion.forum_threads_path, exact: true do %><%= icon "fas", "circle" %> All<% end %></div>
+        <div><%= forum_link_to simple_discussion.forum_threads_path, exact: true do %><%= icon "fa-fw fas", "circle" %> All<% end %></div>
         <% ForumCategory.sorted.each do |category| %>
           <div>
             <%= forum_link_to simple_discussion.forum_category_forum_threads_path(category) do %>
-              <%= icon "fas", "circle", style: "color: #{category.color}" %>
+              <%= icon "fa-fw fas", "circle", style: "color: #{category.color}" %>
               <%= category.name %>
             <% end %>
           </div>
@@ -77,9 +77,9 @@
 
         <%= link_to simple_discussion.forum_thread_notifications_path(@forum_thread), method: :post, class: "btn btn-secondary btn-sm btn-block mb-2" do %>
           <% if @forum_thread.subscribed? current_user %>
-            <%= icon "fas", "bell-slash" %> <%= t('.unsubscribe') %>
+            <%= icon "fa-fw fas", "bell-slash" %> <%= t('.unsubscribe') %>
           <% else %>
-            <%= icon "fas", "bell" %>
+            <%= icon "fa-fw fas", "bell" %>
             <%= t('.suscribe') %>
           <% end %>
         <% end %>

--- a/app/views/layouts/simple_discussion.html.erb
+++ b/app/views/layouts/simple_discussion.html.erb
@@ -19,32 +19,32 @@
         </h5>
         <div>
           <%= forum_link_to simple_discussion.forum_threads_path, exact: true do %>
-            <%= icon "bars" %>
+            <%= icon "fas", "bars" %>
             <%= t('.all_threads') %>
           <% end %>
         </div>
         <% if user_signed_in? %>
           <div>
-            <%= forum_link_to simple_discussion.mine_forum_threads_path do %><%= icon "user-circle-o" %>
+            <%= forum_link_to simple_discussion.mine_forum_threads_path do %><%= icon "far", "user-circle" %>
               <%= t('.my_questions') %>
             <% end %>
           </div>
           <div>
             <%= forum_link_to simple_discussion.participating_forum_threads_path do %>
-              <%= icon "comments-o" %>
+              <%= icon "far", "comments" %>
               <%= t('.participating') %>
             <% end %>
           </div>
         <% end %>
         <div>
           <%= forum_link_to simple_discussion.answered_forum_threads_path do %>
-            <%= icon "check" %>
+            <%= icon "fas", "check" %>
             <%= t('.answered') %>
           <% end %>
         </div>
         <div>
           <%= forum_link_to simple_discussion.unanswered_forum_threads_path do %>
-            <%= icon "question" %>
+            <%= icon "fas", "question" %>
             <%= t('.unanswered') %>
           <% end %>
         </div>
@@ -58,11 +58,11 @@
             <%= t('.by_category') %>
           </strong>
         </h6>
-        <div><%= forum_link_to simple_discussion.forum_threads_path, exact: true do %><%= icon "circle" %> All<% end %></div>
+        <div><%= forum_link_to simple_discussion.forum_threads_path, exact: true do %><%= icon "fas", "circle" %> All<% end %></div>
         <% ForumCategory.sorted.each do |category| %>
           <div>
             <%= forum_link_to simple_discussion.forum_category_forum_threads_path(category) do %>
-              <%= icon "circle", style: "color: #{category.color}" %>
+              <%= icon "fas", "circle", style: "color: #{category.color}" %>
               <%= category.name %>
             <% end %>
           </div>
@@ -77,9 +77,9 @@
 
         <%= link_to simple_discussion.forum_thread_notifications_path(@forum_thread), method: :post, class: "btn btn-secondary btn-sm btn-block mb-2" do %>
           <% if @forum_thread.subscribed? current_user %>
-            <%= icon "bell-slash" %> <%= t('.unsubscribe') %>
+            <%= icon "fas", "bell-slash" %> <%= t('.unsubscribe') %>
           <% else %>
-            <%= icon "bell" %>
+            <%= icon "fas", "bell" %>
             <%= t('.suscribe') %>
           <% end %>
         <% end %>

--- a/app/views/simple_discussion/forum_posts/_forum_post.html.erb
+++ b/app/views/simple_discussion/forum_posts/_forum_post.html.erb
@@ -10,6 +10,13 @@
           data: { toggle: "tooltip", placement: "left" },
           title: t('edit_this_post')
         %>
+        &nbsp;
+        <%= link_to icon("fas","trash"), simple_discussion.forum_thread_forum_post_path(@forum_thread, forum_post),
+          class: "text-muted",
+          method: :delete, 
+          data: { toggle: "tooltip", placement: "left", confirm: "Are you sure you want to delete this post?" },
+          title: t('edit_this_post')
+        %>
       </div>
     <% end %>
 

--- a/app/views/simple_discussion/forum_posts/_forum_post.html.erb
+++ b/app/views/simple_discussion/forum_posts/_forum_post.html.erb
@@ -4,8 +4,8 @@
   <div class="card-header">
 
     <% if is_moderator_or_owner?(forum_post) %>
-      <div class="pull-right">
-        <%= link_to icon("fas","pencil"), simple_discussion.edit_forum_thread_forum_post_path(@forum_thread, forum_post),
+      <div class="float-right">
+        <%= link_to icon("fas","edit"), simple_discussion.edit_forum_thread_forum_post_path(@forum_thread, forum_post),
           class: "text-muted",
           data: { toggle: "tooltip", placement: "left" },
           title: t('edit_this_post')

--- a/app/views/simple_discussion/forum_posts/_forum_post.html.erb
+++ b/app/views/simple_discussion/forum_posts/_forum_post.html.erb
@@ -5,7 +5,7 @@
 
     <% if is_moderator_or_owner?(forum_post) %>
       <div class="pull-right">
-        <%= link_to icon("pencil"), simple_discussion.edit_forum_thread_forum_post_path(@forum_thread, forum_post),
+        <%= link_to icon("fas","pencil"), simple_discussion.edit_forum_thread_forum_post_path(@forum_thread, forum_post),
           class: "text-muted",
           data: { toggle: "tooltip", placement: "left" },
           title: t('edit_this_post')
@@ -33,7 +33,7 @@
   <% if @forum_thread.solved? && forum_post.solved? %>
     <div class="card-footer">
       <div class="pull-right">
-        <strong class="text-success"><%= icon("check") %> <%= t('solved') %></strong>
+        <strong class="text-success"><%= icon("fas","fas","check") %> <%= t('solved') %></strong>
 
         <% if is_moderator_or_owner?(@forum_thread) %>
           <small>
@@ -48,7 +48,7 @@
       <div class="pull-right">
         <small>
           <%= link_to simple_discussion.solved_forum_thread_forum_post_path(@forum_thread, forum_post), method: :put do %>
-            <%= icon("check") %>
+            <%= icon("fas","fas","check") %>
             <%= t('this_solved_my_question') %>
           <% end %>
         </small>

--- a/app/views/simple_discussion/forum_posts/_forum_post.html.erb
+++ b/app/views/simple_discussion/forum_posts/_forum_post.html.erb
@@ -40,7 +40,7 @@
   <% if @forum_thread.solved? && forum_post.solved? %>
     <div class="card-footer">
       <div class="pull-right">
-        <strong class="text-success"><%= icon("fas","fas","check") %> <%= t('solved') %></strong>
+        <strong class="text-success"><%= icon("fas","check") %> <%= t('solved') %></strong>
 
         <% if is_moderator_or_owner?(@forum_thread) %>
           <small>

--- a/app/views/simple_discussion/forum_threads/_forum_thread.html.erb
+++ b/app/views/simple_discussion/forum_threads/_forum_thread.html.erb
@@ -9,11 +9,11 @@
       <div class="col">
         <h4>
           <% if forum_thread.solved? %>
-            <span class="text-success"><%= icon "check-circle" %></span>
+            <span class="text-success"><%= icon "fas", "check-circle" %></span>
           <% end %>
 
           <%= link_to simple_discussion.forum_thread_path(forum_thread) do %>
-            <%= icon "thumb-tack", class: "text-muted" if forum_thread.pinned? %> <%= forum_thread.title %>
+            <%= icon "fas", "thumb-tack", class: "text-muted" if forum_thread.pinned? %> <%= forum_thread.title %>
           <% end %>
         </h4>
 

--- a/app/views/simple_discussion/forum_threads/show.html.erb
+++ b/app/views/simple_discussion/forum_threads/show.html.erb
@@ -1,11 +1,11 @@
 <div class="row">
   <div class="col-md-11">
-    <h1><%= icon "thumb-tack", class: "text-muted" if @forum_thread.pinned? %> <%= @forum_thread.title %></h1>
+    <h1><%= icon "fas", "thumb-tack", class: "text-muted" if @forum_thread.pinned? %> <%= @forum_thread.title %></h1>
   </div>
 
   <% if is_moderator_or_owner?(@forum_thread) %>
     <div class="col-md-1">
-      <%= link_to icon("pencil"), simple_discussion.edit_forum_thread_path(@forum_thread),
+      <%= link_to icon("fas","pencil"), simple_discussion.edit_forum_thread_path(@forum_thread),
         class: "text-muted",
         data: { toggle: "tooltip", placement: "left" },
         title: t('edit_this_thread') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,7 +4,7 @@ en:
   ask_a_question: Ask A Question
   asked_time_ago: "Asked %{time} ago by %{author}"
   choose_a_category: Choose a Category
-  comment: comment
+  comment: Comment
   commented_on: Commented on
   community: Community
   edit_this_post: Edit this post

--- a/lib/simple_discussion/version.rb
+++ b/lib/simple_discussion/version.rb
@@ -1,3 +1,3 @@
 module SimpleDiscussion
-  VERSION = "1.0.1"
+  VERSION = "1.1.0"
 end

--- a/simple_discussion.gemspec
+++ b/simple_discussion.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'font-awesome-sass', '>= 4.7.0'
+  spec.add_dependency 'font-awesome-sass', '~> 4.7.0'
   spec.add_dependency 'friendly_id', '>= 5.2.0'
   spec.add_dependency 'gravatar_image_tag'
   spec.add_dependency 'rails', '>= 4.2'

--- a/simple_discussion.gemspec
+++ b/simple_discussion.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'font-awesome-sass', '~> 4.7.0'
+  spec.add_dependency 'font-awesome-sass', '~> 5.13.0'
   spec.add_dependency 'friendly_id', '>= 5.2.0'
   spec.add_dependency 'gravatar_image_tag'
   spec.add_dependency 'rails', '>= 4.2'


### PR DESCRIPTION
I had an error during start up:
```
ActionView::Template::Error (wrong number of arguments (given 1, expected 2..4)):
    19:         </h5>
    20:         <div>
    21:           <%= forum_link_to simple_discussion.forum_threads_path, exact: true do %>
    22:             <%= icon "bars" %>
    23:             <%= t('.all_threads') %>
    24:           <% end %>
    25:         </div>

font-awesome-sass (5.13.0) lib/font_awesome/sass/rails/helpers.rb:5:in `icon'
```

`font-awesome-sass` v5 introduced a breaking change to the `icon` method which requires a minimum of two parameters. See: https://github.com/FortAwesome/font-awesome-sass/blob/9e5a7858ad409911b1f0db1c4de2c790e2b2d995/lib/font_awesome/sass/rails/helpers.rb

This PR pins the major version to v4 which fixes this.