### PR TITLE
Fixed incorrect title represent on delete button

### DIFF
--- a/app/views/simple_discussion/forum_posts/_forum_post.html.erb
+++ b/app/views/simple_discussion/forum_posts/_forum_post.html.erb
@@ -15,7 +15,7 @@
           class: "text-muted",
           method: :delete, 
           data: { toggle: "tooltip", placement: "left", confirm: "Are you sure you want to delete this post?" },
-          title: t('edit_this_post')
+          title: t('delete_this_post')
         %>
       </div>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,7 @@ en:
   commented_on: Commented on
   community: Community
   edit_this_post: Edit this post
+  delete_this_post: Delete this post
   edit_this_thread: Edit this thread
   edit_thread: Edit thread
   filters: Filters


### PR DESCRIPTION
# Purpose

I noticed that while hovering over `delete` icon on a post, it shows `Edit the post` which although is not a big deal but still is not correct. I took this opportunity to fix it

# Before

![image](https://user-images.githubusercontent.com/46072181/89748258-630a8100-da90-11ea-8a8e-21cc8f8ef493.png)

# After
![image](https://user-images.githubusercontent.com/46072181/89748278-74ec2400-da90-11ea-8cbe-1cd1ac546b70.png)


