### PR TITLE
use action text by default

### DIFF
--- a/app/helpers/simple_discussion/forum_posts_helper.rb
+++ b/app/helpers/simple_discussion/forum_posts_helper.rb
@@ -9,11 +9,6 @@ module SimpleDiscussion::ForumPostsHelper
       style: "color: #{category.color}"
   end
 
-  # Override this method to provide your own content formatting like Markdown
-  def formatted_content(text)
-    simple_format(text)
-  end
-
   def forum_post_classes(forum_post)
     klasses = ["forum-post", "card", "mb-3"]
     klasses << "solved" if forum_post.solved?

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -1,6 +1,8 @@
 class ForumPost < ApplicationRecord
   belongs_to :forum_thread, counter_cache: true, touch: true
   belongs_to :user
+  
+  has_rich_text :body
 
   validates :user_id, :body, presence: true
 

--- a/app/views/simple_discussion/forum_posts/_form.html.erb
+++ b/app/views/simple_discussion/forum_posts/_form.html.erb
@@ -15,7 +15,7 @@
   <% end %>
 
   <div class="form-group">
-    <%= f.text_area :body, placeholder: t('add_a_comment'), rows: 8, class: "form-control simplemde", data: { behavior: "comment-body" } %>
+    <%= f.rich_text_area :body, placeholder: t('add_a_comment'), rows: 8, class: "form-control simplemde", data: { behavior: "comment-body" } %>
   </div>
 
   <div class="text-right">

--- a/app/views/simple_discussion/forum_posts/_forum_post.html.erb
+++ b/app/views/simple_discussion/forum_posts/_forum_post.html.erb
@@ -34,7 +34,7 @@
   </div>
 
   <div class="card-body">
-    <%= formatted_content forum_post.body %>
+    <%= forum_post.body %>
   </div>
 
   <% if @forum_thread.solved? && forum_post.solved? %>

--- a/app/views/simple_discussion/forum_threads/_form.html.erb
+++ b/app/views/simple_discussion/forum_threads/_form.html.erb
@@ -28,7 +28,7 @@
     <%= f.fields_for :forum_posts do |p| %>
       <div class="form-group">
         <%= p.label :body, t('what_help_needed') %>
-        <%= p.text_area :body, placeholder: t('add_a_comment'), rows: 10, class: "form-control simplemde", data: { behavior: "comment-body" } %>
+        <%= p.rich_text_area :body, placeholder: t('add_a_comment'), rows: 10, class: "form-control simplemde", data: { behavior: "comment-body" } %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/simple_discussion/forum_threads/_forum_thread.html.erb
+++ b/app/views/simple_discussion/forum_threads/_forum_thread.html.erb
@@ -22,7 +22,7 @@
           • <%= t('asked_time_ago', time: time_ago_in_words(forum_thread.created_at), author: forum_thread.user.name) %>
         </div>
 
-        <p class="text-muted"><%= truncate(forum_thread.forum_posts.first.body, length: 200) %></p>
+        <p class="text-muted"><%= truncate(forum_thread.forum_posts.first.body.to_plain_text, length: 200) %></p>
       </div>
 
       <div class="col-sm-2 text-center">

--- a/app/views/simple_discussion/user_mailer/new_post.html.erb
+++ b/app/views/simple_discussion/user_mailer/new_post.html.erb
@@ -3,7 +3,7 @@
 
   <div style="margin-left:60px">
     <p><strong><%= @forum_post.user.name %></strong> <small>commented:</small></p>
-    <%= formatted_content @forum_post.body %>
+    <%= @forum_post.body %>
   </div>
 </div>
 

--- a/app/views/simple_discussion/user_mailer/new_thread.html.erb
+++ b/app/views/simple_discussion/user_mailer/new_thread.html.erb
@@ -3,7 +3,7 @@
 
   <div style="margin-left:60px">
     <p><strong><%= @forum_post.user.name %></strong> <small>commented:</small></p>
-    <%= formatted_content @forum_post.body %>
+    <%= @forum_post.body %>
   </div>
 </div>
 


### PR DESCRIPTION
Now that rails has action text, the gem can use it for formatting by default.